### PR TITLE
feat: add Scala 3 / sbt 2.x cross-build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Scala CI
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,16 +8,20 @@ flyway-sbt is an sbt plugin that integrates [Flyway](https://flywaydb.org) datab
 
 ## Build & Test
 
-- **sbt version**: 1.10.1
-- **Scala**: Cross-builds for 2.12.20 and 2.13.16
+- **sbt version**: 1.12.8
+- **Scala**: Cross-builds for 2.12.20 (sbt 1.x) and 3.8.2 (sbt 2.x)
 - **Java**: Tested on JDK 11, 17, 21
 
 ```bash
-# Compile
-sbt compile
+# Compile (cross-build)
+sbt +compile
+
+# Compile for specific Scala version
+sbt "++2.12.20 compile"
+sbt "++3.8.2 compile"
 
 # Run scripted (integration) tests — this is the primary test suite
-sbt scripted
+sbt "++2.12.20 scripted"
 
 # Publish locally for testing
 sbt publishLocal
@@ -27,14 +31,22 @@ There are no unit tests. All testing uses sbt's [scripted test framework](http:/
 
 ## Architecture
 
-This is a single-file sbt plugin. The entire implementation lives in `src/main/scala/io/github/ijufumi/FlywayPlugin.scala`.
+The plugin implementation is split across shared and version-specific source directories:
+
+- `src/main/scala/` — shared code (FlywayPlugin.scala)
+- `src/main/scala-2.12/` — Scala 2.12 / sbt 1.x specific code
+- `src/main/scala-3/` — Scala 3 / sbt 2.x specific code
 
 **Key structure within FlywayPlugin:**
 - `autoImport` — defines all public sbt settings (`flywayUrl`, `flywayUser`, etc.) and tasks (`flywayMigrate`, `flywayValidate`, `flywayInfo`, `flywayClean`, `flywayBaseline`, `flywayRepair`)
-- Private `Config*` case classes — group related settings into typed configuration bundles
+- `Config*` case classes — group related settings into typed configuration bundles
 - `FluentConfigurationOps` implicit — chains config bundles onto Flyway's `FluentConfiguration`
 - `withContextClassLoader` — sets up the classloader from sbt's classpath so Flyway can find JDBC drivers and migrations
 - `SbtLogCreator` / `FlywaySbtLog` — bridges Flyway's logging to sbt's logger
+
+**Version-specific code:**
+- `compat.scala` — provides `CollectionConverters` (JavaConverters for 2.12, jdk.CollectionConverters for 3) and `classpathUrls` (handles File vs VirtualFileRef classpath differences)
+- `FlywayTaskDefs.scala` — task definitions (sbt 2.x requires `Def.uncached` for tasks without `HashWriter`)
 
 The plugin is `noTrigger` — users must explicitly `enablePlugins(FlywayPlugin)`. Settings are provided for both `Runtime` and `Test` configurations.
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,20 @@ val flywayVersion = "9.22.3"
 val pluginVersion = "9.22.3.1"
 
 val scala212Version = "2.12.20"
-val scala213Version = "2.13.16"
+val scala3Version = "3.8.2"
 
-lazy val supportedScalaVersions = Seq(scala212Version, scala213Version)
+lazy val supportedScalaVersions = Seq(scala212Version, scala3Version)
 
-// ThisBuild / scalaVersion := scala212Version
 ThisBuild / crossScalaVersions := supportedScalaVersions
 
 ThisBuild / versionScheme := Some("early-semver")
+
+(pluginCrossBuild / sbtVersion) := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.12.8"
+    case _      => "2.0.0-RC9"
+  }
+}
 
 lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin)
@@ -22,18 +28,37 @@ lazy val root = (project in file("."))
     scalacOptions ++= Seq(
       "-deprecation",
       "-unchecked",
-      "-Xfuture",
     ),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Seq("-Xfuture")
+        case _ => Seq(
+          "-Wconf:msg=is deprecated for wildcard arguments:s",
+          "-Wconf:msg=is no longer supported for vararg splices:s",
+        )
+      }
+    },
+    Compile / unmanagedSourceDirectories += {
+      val sourceDir = (Compile / sourceDirectory).value
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n <= 12 => sourceDir / "scala-2.12"
+        case _                       => sourceDir / "scala-3"
+      }
+    },
     Compile / doc / scalacOptions ++= {
-      Seq(
-        "-sourcepath",
-        (LocalRootProject / baseDirectory).value.getAbsolutePath,
-        "-doc-source-url",
-        s"""https://github.com/ijufumi/flyway-sbt/tree/${sys.process
-          .Process("git rev-parse HEAD")
-          .lineStream_!
-          .head}€{FILE_PATH}.scala""",
-      )
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "-sourcepath",
+            (LocalRootProject / baseDirectory).value.getAbsolutePath,
+            "-doc-source-url",
+            s"""https://github.com/ijufumi/flyway-sbt/tree/${sys.process
+              .Process("git rev-parse HEAD")
+              .lineStream_!
+              .head}€{FILE_PATH}.scala""",
+          )
+        case _ => Seq.empty
+      }
     },
     scriptedLaunchOpts := {
       scriptedLaunchOpts.value ++

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-sbt.version=1.10.1
+sbt.version=1.12.8

--- a/src/main/scala-2.12/io/github/ijufumi/FlywayTaskDefs.scala
+++ b/src/main/scala-2.12/io/github/ijufumi/FlywayTaskDefs.scala
@@ -1,0 +1,98 @@
+package io.github.ijufumi
+
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.internal.info.MigrationInfoDumper
+import sbt.Keys._
+import sbt._
+
+import FlywayPlugin._
+import FlywayPlugin.autoImport._
+
+object FlywayTaskDefs {
+
+  def flywayTaskSettings(conf: Configuration): Seq[Setting[_]] = {
+    Seq[Setting[_]](
+      flywayConfigDataSource := ConfigDataSource(
+        flywayDriver.value,
+        flywayUrl.value,
+        flywayUser.value,
+        flywayPassword.value,
+      ),
+      flywayConfigBase := ConfigBase(
+        flywaySchemas.value,
+        flywayTable.value,
+        flywayBaselineVersion.value,
+        flywayBaselineDescription.value,
+      ),
+      flywayConfigMigrationLoading := ConfigMigrationLoading(
+        flywayLocations.value,
+        flywayResolvers.value,
+        flywaySkipDefaultResolvers.value,
+        flywayEncoding.value,
+        flywayCleanOnValidationError.value,
+        flywayCleanDisabled.value,
+        flywayTarget.value,
+        flywayOutOfOrder.value,
+        flywayCallbacks.value,
+        flywaySkipDefaultCallbacks.value,
+      ),
+      flywayConfigSqlMigration := ConfigSqlMigration(
+        flywaySqlMigrationPrefix.value,
+        flywayRepeatableSqlMigrationPrefix.value,
+        flywaySqlMigrationSeparator.value,
+        flywaySqlMigrationSuffixes.value,
+      ),
+      flywayConfigMigrate := ConfigMigrate(
+        flywayIgnoreMissingMigrations.value,
+        flywayIgnoreFutureMigrations.value,
+        flywayIgnoreFailedFutureMigration.value,
+        flywayBaselineOnMigrate.value,
+        flywayValidateOnMigrate.value,
+        flywayMixed.value,
+        flywayGroup.value,
+        flywayInstalledBy.value,
+      ),
+      flywayConfigPlaceholder := ConfigPlaceholder(
+        flywayPlaceholderReplacement.value,
+        flywayPlaceholders.value,
+        flywayPlaceholderPrefix.value,
+        flywayPlaceholderSuffix.value,
+      ),
+      flywayConfig := Config(
+        flywayConfigDataSource.value,
+        flywayConfigBase.value,
+        flywayConfigMigrationLoading.value,
+        flywayConfigSqlMigration.value,
+        flywayConfigMigrate.value,
+        flywayConfigPlaceholder.value,
+      ),
+      flywayClasspath := Def.taskDyn {
+        if (flywayLocations.value.forall(_.startsWith("filesystem:"))) {
+          conf / externalDependencyClasspath
+        } else {
+          conf / fullClasspath
+        }
+      }.value,
+      flywayDefaults := withPrepared(flywayClasspath.value, streams.value)(
+        Flyway.configure(),
+      ),
+      flywayMigrate := flywayDefaults.value
+        .configure(flywayConfig.value)
+        .migrate(),
+      flywayValidate := flywayDefaults.value
+        .configure(flywayConfig.value)
+        .validate(),
+      flywayInfo := {
+        val info = flywayDefaults.value.configure(flywayConfig.value).info()
+        streams.value.log.info(MigrationInfoDumper.dumpToAsciiTable(info.all()))
+      },
+      flywayRepair := flywayDefaults.value
+        .configure(flywayConfig.value)
+        .repair(),
+      flywayClean := flywayDefaults.value.configure(flywayConfig.value).clean(),
+      flywayBaseline := flywayDefaults.value
+        .configure(flywayConfig.value)
+        .baseline(),
+    )
+  }
+}

--- a/src/main/scala-2.12/io/github/ijufumi/compat.scala
+++ b/src/main/scala-2.12/io/github/ijufumi/compat.scala
@@ -1,0 +1,12 @@
+package io.github.ijufumi
+
+import java.net.URL
+import sbt._
+import sbt.Keys.Classpath
+
+package object compat {
+  val CollectionConverters = scala.collection.JavaConverters
+
+  def classpathUrls(cp: Classpath): Array[URL] =
+    cp.map(_.data.toURI.toURL).toArray
+}

--- a/src/main/scala-3/io/github/ijufumi/FlywayTaskDefs.scala
+++ b/src/main/scala-3/io/github/ijufumi/FlywayTaskDefs.scala
@@ -1,0 +1,126 @@
+package io.github.ijufumi
+
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.internal.info.MigrationInfoDumper
+import sbt.Keys.*
+import sbt.*
+
+import FlywayPlugin.*
+import FlywayPlugin.autoImport.*
+
+object FlywayTaskDefs {
+
+  def flywayTaskSettings(conf: Configuration): Seq[Setting[?]] = {
+    Seq[Setting[?]](
+      flywayConfigDataSource := Def.uncached {
+        ConfigDataSource(
+          flywayDriver.value,
+          flywayUrl.value,
+          flywayUser.value,
+          flywayPassword.value,
+        )
+      },
+      flywayConfigBase := Def.uncached {
+        ConfigBase(
+          flywaySchemas.value,
+          flywayTable.value,
+          flywayBaselineVersion.value,
+          flywayBaselineDescription.value,
+        )
+      },
+      flywayConfigMigrationLoading := Def.uncached {
+        ConfigMigrationLoading(
+          flywayLocations.value,
+          flywayResolvers.value,
+          flywaySkipDefaultResolvers.value,
+          flywayEncoding.value,
+          flywayCleanOnValidationError.value,
+          flywayCleanDisabled.value,
+          flywayTarget.value,
+          flywayOutOfOrder.value,
+          flywayCallbacks.value,
+          flywaySkipDefaultCallbacks.value,
+        )
+      },
+      flywayConfigSqlMigration := Def.uncached {
+        ConfigSqlMigration(
+          flywaySqlMigrationPrefix.value,
+          flywayRepeatableSqlMigrationPrefix.value,
+          flywaySqlMigrationSeparator.value,
+          flywaySqlMigrationSuffixes.value,
+        )
+      },
+      flywayConfigMigrate := Def.uncached {
+        ConfigMigrate(
+          flywayIgnoreMissingMigrations.value,
+          flywayIgnoreFutureMigrations.value,
+          flywayIgnoreFailedFutureMigration.value,
+          flywayBaselineOnMigrate.value,
+          flywayValidateOnMigrate.value,
+          flywayMixed.value,
+          flywayGroup.value,
+          flywayInstalledBy.value,
+        )
+      },
+      flywayConfigPlaceholder := Def.uncached {
+        ConfigPlaceholder(
+          flywayPlaceholderReplacement.value,
+          flywayPlaceholders.value,
+          flywayPlaceholderPrefix.value,
+          flywayPlaceholderSuffix.value,
+        )
+      },
+      flywayConfig := Def.uncached {
+        Config(
+          flywayConfigDataSource.value,
+          flywayConfigBase.value,
+          flywayConfigMigrationLoading.value,
+          flywayConfigSqlMigration.value,
+          flywayConfigMigrate.value,
+          flywayConfigPlaceholder.value,
+        )
+      },
+      flywayClasspath := Def.uncached {
+        Def.taskDyn {
+          if (flywayLocations.value.forall(_.startsWith("filesystem:"))) {
+            conf / externalDependencyClasspath
+          } else {
+            conf / fullClasspath
+          }
+        }.value
+      },
+      flywayDefaults := Def.uncached {
+        withPrepared(flywayClasspath.value, streams.value)(
+          Flyway.configure(),
+        )
+      },
+      flywayMigrate := Def.uncached {
+        flywayDefaults.value
+          .configure(flywayConfig.value)
+          .migrate()
+      },
+      flywayValidate := Def.uncached {
+        flywayDefaults.value
+          .configure(flywayConfig.value)
+          .validate()
+      },
+      flywayInfo := Def.uncached {
+        val info = flywayDefaults.value.configure(flywayConfig.value).info()
+        streams.value.log.info(MigrationInfoDumper.dumpToAsciiTable(info.all()))
+      },
+      flywayRepair := Def.uncached {
+        flywayDefaults.value
+          .configure(flywayConfig.value)
+          .repair()
+      },
+      flywayClean := Def.uncached {
+        flywayDefaults.value.configure(flywayConfig.value).clean()
+      },
+      flywayBaseline := Def.uncached {
+        flywayDefaults.value
+          .configure(flywayConfig.value)
+          .baseline()
+      },
+    )
+  }
+}

--- a/src/main/scala-3/io/github/ijufumi/compat.scala
+++ b/src/main/scala-3/io/github/ijufumi/compat.scala
@@ -1,0 +1,13 @@
+package io.github.ijufumi
+
+import java.net.URL
+import java.nio.file.Paths
+import sbt._
+import sbt.Keys.Classpath
+
+package object compat {
+  val CollectionConverters = scala.jdk.CollectionConverters
+
+  def classpathUrls(cp: Classpath): Array[URL] =
+    cp.map(entry => Paths.get(entry.data.id).toUri.toURL).toArray
+}

--- a/src/main/scala/io/github/ijufumi/FlywayPlugin.scala
+++ b/src/main/scala/io/github/ijufumi/FlywayPlugin.scala
@@ -17,12 +17,12 @@ import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.callback.Callback
 import org.flywaydb.core.api.logging.{Log, LogCreator, LogFactory}
 import org.flywaydb.core.internal.info.MigrationInfoDumper
-import sbt.Keys.*
-import sbt.*
+import sbt.Keys._
+import sbt._
 
-import scala.collection.JavaConverters.*
+import _root_.io.github.ijufumi.compat.CollectionConverters._
+import _root_.io.github.ijufumi.compat.classpathUrls
 import org.flywaydb.core.api.configuration.FluentConfiguration
-import sbt.io.PathFinder
 
 import java.net.URLClassLoader
 import scala.collection.mutable.Map
@@ -169,7 +169,7 @@ object FlywayPlugin extends AutoPlugin {
   // *********************
   // convenience settings
   // *********************
-  private case class ConfigDataSource(
+  private[ijufumi] case class ConfigDataSource(
       driver: String,
       url: String,
       user: String,
@@ -185,13 +185,13 @@ object FlywayPlugin extends AutoPlugin {
       "flyway.password" -> password,
     )
   }
-  private case class ConfigBase(
+  private[ijufumi] case class ConfigBase(
       schemas: Seq[String],
       table: String,
       baselineVersion: String,
       baselineDescription: String,
   )
-  private case class ConfigMigrationLoading(
+  private[ijufumi] case class ConfigMigrationLoading(
       locations: Seq[String],
       resolvers: Seq[String],
       skipDefaultResolvers: Boolean,
@@ -203,13 +203,13 @@ object FlywayPlugin extends AutoPlugin {
       callbacks: Seq[Callback],
       skipDefaultCallbacks: Boolean,
   )
-  private case class ConfigSqlMigration(
+  private[ijufumi] case class ConfigSqlMigration(
       sqlMigrationPrefix: String,
       repeatableSqlMigrationPrefix: String,
       sqlMigrationSeparator: String,
-      sqlMigrationSuffixes: String*,
+      sqlMigrationSuffixes: Seq[String],
   )
-  private case class ConfigMigrate(
+  private[ijufumi] case class ConfigMigrate(
       ignoreMissingMigrations: Boolean,
       ignoreFutureMigrations: Boolean,
       ignoreFailedMigrations: Boolean,
@@ -219,13 +219,13 @@ object FlywayPlugin extends AutoPlugin {
       group: Boolean,
       installedBy: String,
   )
-  private case class ConfigPlaceholder(
+  private[ijufumi] case class ConfigPlaceholder(
       placeholderReplacement: Boolean,
       placeholders: Map[String, String],
       placeholderPrefix: String,
       placeholderSuffix: String,
   )
-  private case class Config(
+  private[ijufumi] case class Config(
       dataSource: ConfigDataSource,
       base: ConfigBase,
       migrationLoading: ConfigMigrationLoading,
@@ -234,23 +234,24 @@ object FlywayPlugin extends AutoPlugin {
       placeholder: ConfigPlaceholder,
   )
 
-  private lazy val flywayConfigDataSource =
+  private[ijufumi] lazy val flywayConfigDataSource =
     taskKey[ConfigDataSource]("The Flyway data source configuration.")
-  private lazy val flywayConfigBase =
+  private[ijufumi] lazy val flywayConfigBase =
     taskKey[ConfigBase]("The Flyway base configuration.")
-  private lazy val flywayConfigMigrationLoading =
+  private[ijufumi] lazy val flywayConfigMigrationLoading =
     taskKey[ConfigMigrationLoading](
       "The Flyway migration loading configuration.",
     )
-  private lazy val flywayConfigSqlMigration =
+  private[ijufumi] lazy val flywayConfigSqlMigration =
     taskKey[ConfigSqlMigration]("The Flyway sql migration configuration.")
-  private lazy val flywayConfigMigrate =
+  private[ijufumi] lazy val flywayConfigMigrate =
     taskKey[ConfigMigrate]("The Flyway migrate configuration.")
-  private lazy val flywayConfigPlaceholder =
+  private[ijufumi] lazy val flywayConfigPlaceholder =
     taskKey[ConfigPlaceholder]("The Flyway placeholder configuration.")
-  private lazy val flywayConfig = taskKey[Config]("The Flyway configuration.")
-  private lazy val flywayClasspath =
-    taskKey[Types.Id[Classpath]]("The classpath used by Flyway.")
+  private[ijufumi] lazy val flywayConfig =
+    taskKey[Config]("The Flyway configuration.")
+  private[ijufumi] lazy val flywayClasspath =
+    taskKey[Classpath]("The classpath used by Flyway.")
 
   // *********************
   // flyway defaults
@@ -261,13 +262,21 @@ object FlywayPlugin extends AutoPlugin {
   def flywayBaseSettings(conf: Configuration): Seq[Setting[_]] = {
     import FlywayPlugin.autoImport._
     val defaults = getFlywayDefaults
+    flywaySettingSettings(defaults) ++
+      FlywayTaskDefs.flywayTaskSettings(conf)
+  }
+
+  private def flywaySettingSettings(
+      defaults: FluentConfiguration,
+  ): Seq[Setting[_]] = {
+    import FlywayPlugin.autoImport._
     Seq[Setting[_]](
       flywayDriver := "",
       flywayUrl := "",
       flywayUser := "",
       flywayPassword := "",
       flywayLocations := List("db/migration"),
-      flywayResolvers := Array.empty[String],
+      flywayResolvers := Seq.empty[String],
       flywaySkipDefaultResolvers := defaults.isSkipDefaultResolvers,
       flywaySchemas := defaults.getSchemas.toSeq,
       flywayTable := defaults.getTable,
@@ -277,10 +286,10 @@ object FlywayPlugin extends AutoPlugin {
       flywaySqlMigrationPrefix := defaults.getSqlMigrationPrefix,
       flywayRepeatableSqlMigrationPrefix := defaults.getRepeatableSqlMigrationPrefix,
       flywaySqlMigrationSeparator := defaults.getSqlMigrationSeparator,
-      flywaySqlMigrationSuffixes := defaults.getSqlMigrationSuffixes,
+      flywaySqlMigrationSuffixes := defaults.getSqlMigrationSuffixes.toSeq,
       flywayTarget := "current",
       flywayOutOfOrder := defaults.isOutOfOrder,
-      flywayCallbacks := new Array[Callback](0),
+      flywayCallbacks := Seq.empty[Callback],
       flywaySkipDefaultCallbacks := defaults.isSkipDefaultCallbacks,
       flywayIgnoreMissingMigrations := false,
       flywayIgnoreFutureMigrations := false,
@@ -296,102 +305,18 @@ object FlywayPlugin extends AutoPlugin {
       flywayInstalledBy := "",
       flywayCleanOnValidationError := defaults.isCleanOnValidationError,
       flywayCleanDisabled := defaults.isCleanDisabled,
-      flywayConfigDataSource := ConfigDataSource(
-        flywayDriver.value,
-        flywayUrl.value,
-        flywayUser.value,
-        flywayPassword.value,
-      ),
-      flywayConfigBase := ConfigBase(
-        flywaySchemas.value,
-        flywayTable.value,
-        flywayBaselineVersion.value,
-        flywayBaselineDescription.value,
-      ),
-      flywayConfigMigrationLoading := ConfigMigrationLoading(
-        flywayLocations.value,
-        flywayResolvers.value,
-        flywaySkipDefaultResolvers.value,
-        flywayEncoding.value,
-        flywayCleanOnValidationError.value,
-        flywayCleanDisabled.value,
-        flywayTarget.value,
-        flywayOutOfOrder.value,
-        flywayCallbacks.value,
-        flywaySkipDefaultCallbacks.value,
-      ),
-      flywayConfigSqlMigration := ConfigSqlMigration(
-        flywaySqlMigrationPrefix.value,
-        flywayRepeatableSqlMigrationPrefix.value,
-        flywaySqlMigrationSeparator.value,
-        flywaySqlMigrationSuffixes.value: _*,
-      ),
-      flywayConfigMigrate := ConfigMigrate(
-        flywayIgnoreMissingMigrations.value,
-        flywayIgnoreFutureMigrations.value,
-        flywayIgnoreFailedFutureMigration.value,
-        flywayBaselineOnMigrate.value,
-        flywayValidateOnMigrate.value,
-        flywayMixed.value,
-        flywayGroup.value,
-        flywayInstalledBy.value,
-      ),
-      flywayConfigPlaceholder := ConfigPlaceholder(
-        flywayPlaceholderReplacement.value,
-        flywayPlaceholders.value,
-        flywayPlaceholderPrefix.value,
-        flywayPlaceholderSuffix.value,
-      ),
-      flywayConfig := Config(
-        flywayConfigDataSource.value,
-        flywayConfigBase.value,
-        flywayConfigMigrationLoading.value,
-        flywayConfigSqlMigration.value,
-        flywayConfigMigrate.value,
-        flywayConfigPlaceholder.value,
-      ),
-      flywayClasspath := Def.taskDyn {
-        // fullClasspath triggers the compile task, so use a dynamic task to only run it if we need to.
-        // https://github.com/flyway/flyway-sbt/issues/10
-        if (flywayLocations.value.forall(_.startsWith("filesystem:"))) {
-          conf / externalDependencyClasspath
-        } else {
-          conf / fullClasspath
-        }
-      }.value,
-      // Tasks
-      flywayDefaults := withPrepared(flywayClasspath.value, streams.value)(
-        Flyway.configure(),
-      ),
-      flywayMigrate := flywayDefaults.value
-        .configure(flywayConfig.value)
-        .migrate(),
-      flywayValidate := flywayDefaults.value
-        .configure(flywayConfig.value)
-        .validate(),
-      flywayInfo := {
-        val info = flywayDefaults.value.configure(flywayConfig.value).info()
-        streams.value.log.info(MigrationInfoDumper.dumpToAsciiTable(info.all()))
-      },
-      flywayRepair := flywayDefaults.value
-        .configure(flywayConfig.value)
-        .repair(),
-      flywayClean := flywayDefaults.value.configure(flywayConfig.value).clean(),
-      flywayBaseline := flywayDefaults.value
-        .configure(flywayConfig.value)
-        .baseline(),
     )
   }
 
-  private def getFlywayDefaults: FluentConfiguration = {
+  private[ijufumi] def getFlywayDefaults: FluentConfiguration = {
     // This needs to be set so that Flyway could initialize properly
     // See https://github.com/flyway/flyway/issues/1922
     LogFactory.setLogCreator(SbtLogCreator)
     Flyway.configure()
   }
 
-  private def withPrepared[T](
-      cp: Types.Id[Keys.Classpath],
+  private[ijufumi] def withPrepared[T](
+      cp: Classpath,
       streams: TaskStreams,
   )(f: => T): T = {
     registerAsFlywayLogger(streams)
@@ -406,9 +331,10 @@ object FlywayPlugin extends AutoPlugin {
   }
 
   private def withContextClassLoader[T](
-      cp: Types.Id[Keys.Classpath],
+      cp: Classpath,
   )(f: => T): T = {
-    val classloader = toLoader(cp.map(_.data), getClass.getClassLoader)
+    val urls = classpathUrls(cp)
+    val classloader = new URLClassLoader(urls, getClass.getClassLoader)
     val thread = Thread.currentThread
     val oldLoader = thread.getContextClassLoader
     try {
@@ -419,14 +345,14 @@ object FlywayPlugin extends AutoPlugin {
     }
   }
 
-  private implicit class StringOps(val s: String) extends AnyVal {
+  private[ijufumi] implicit class StringOps(val s: String) extends AnyVal {
     def emptyToNull(): String = s match {
       case ss if ss.isEmpty => null
       case _                => s
     }
   }
 
-  private implicit class FluentConfiguratiOnlyOps(
+  private[ijufumi] implicit class FluentConfigurationOps(
       val flyway: FluentConfiguration,
   ) extends AnyVal {
     def configure(config: Config): Flyway = {
@@ -484,7 +410,7 @@ object FlywayPlugin extends AutoPlugin {
         ignorePatterns = ignorePatterns :+ "Future"
       }
       flyway
-        .ignoreMigrationPatterns(ignorePatterns *)
+        .ignoreMigrationPatterns(ignorePatterns: _*)
         .baselineOnMigrate(config.baselineOnMigrate)
         .validateOnMigrate(config.validateOnMigrate)
         .mixed(config.mixed)
@@ -509,9 +435,6 @@ object FlywayPlugin extends AutoPlugin {
       flyway.configuration(props)
     }
   }
-
-  def toLoader(finder: PathFinder, parent: ClassLoader): ClassLoader =
-    new URLClassLoader(finder.getURLs(), parent)
 
   private object SbtLogCreator extends LogCreator {
     def createLogger(clazz: Class[_]): FlywaySbtLog.type = FlywaySbtLog


### PR DESCRIPTION
## Summary
- Scala 2.12 (sbt 1.x) と Scala 3.8.2 (sbt 2.x) のクロスビルドに対応
- バージョン別ソースディレクトリ (`scala-2.12/`, `scala-3/`) を導入し、JavaConverters/CollectionConverters、タスクキャッシュ (`Def.uncached`)、クラスパス型 (File vs VirtualFileRef) の差異を吸収
- sbt を 1.12.8 に更新し、`pluginCrossBuild` で sbt バージョンマッピングを設定
- case class の varargs (`String*`) を `Seq[String]` に変更 (Scala 3 互換)

## Test plan
- [x] `sbt "++2.12.20 compile"` — Scala 2.12 コンパイル成功
- [x] `sbt "++3.8.2 compile"` — Scala 3.8.2 コンパイル成功
- [x] `sbt "++2.12.20 scripted"` — 全4テスト (test1〜test4) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)